### PR TITLE
Add flexGrow between text and icon

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,7 @@ import {makeStyles} from '@material-ui/core/styles'
 import Menu, {MenuProps} from '@material-ui/core/Menu'
 import MenuItem, {MenuItemProps} from '@material-ui/core/MenuItem'
 import ArrowRight from '@material-ui/icons/ArrowRight'
+import Box from '@material-ui/core/Box';
 import clsx from 'clsx'
 
 export interface NestedMenuItemProps extends Omit<MenuItemProps, 'button'> {
@@ -168,6 +169,7 @@ const NestedMenuItem = React.forwardRef<
         ref={menuItemRef}
       >
         {label}
+        <Box sx={{ flexGrow: 1 }} />
         {rightIcon}
       </MenuItem>
       <Menu


### PR DESCRIPTION
It aligns the icon to the right side.

Before
![image](https://user-images.githubusercontent.com/23468720/129305010-17bb7822-e583-478c-8833-4859c6e8b388.png)

After
![image](https://user-images.githubusercontent.com/23468720/129305027-2e2a2ca7-42ea-41e8-9af9-2b69fed61d3c.png)
