### PR TITLE
Pass MenuProps prop to Menu component

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -173,6 +173,7 @@ const NestedMenuItem = React.forwardRef<
       <Menu
         // Set pointer events to 'none' to prevent the invisible Popover div
         // from capturing events for clicks and hovers
+        {...MenuProps}
         style={{pointerEvents: 'none'}}
         anchorEl={menuItemRef.current}
         anchorOrigin={{


### PR DESCRIPTION
MenuProps were received but never passed to the Menu component, what prevented users to manage its props.